### PR TITLE
Changed the "cancel" icon in the edit

### DIFF
--- a/src/editable-form/editable-form-bootstrap.js
+++ b/src/editable-form/editable-form-bootstrap.js
@@ -5,7 +5,7 @@ Editableform based on Twitter Bootstrap
     
     //form template
     $.fn.editableform.template = '<form class="form-inline editableform"><div class="control-group">' + 
-    '&nbsp;<button type="submit" class="btn btn-primary"><i class="icon-ok icon-white"></i></button>&nbsp;<button type="button" class="btn clearfix"><i class="icon-ban-circle"></i></button>' + 
+    '&nbsp;<button type="submit" class="btn btn-primary"><i class="icon-ok icon-white"></i></button>&nbsp;<button type="button" class="btn clearfix"><i class="icon-remove"></i></button>' + 
     '<div style="clear:both"><span class="help-block editable-error-block"></span></div>' + 
     '</div></form>'; 
     

--- a/src/editable-form/editable-form-jqueryui.js
+++ b/src/editable-form/editable-form-jqueryui.js
@@ -13,7 +13,7 @@ Editableform based on jQuery UI
                  text: false
              });
              this.$form.find('button[type=button]').button({
-                 icons: { primary: "ui-icon-cancel" },
+                 icons: { primary: "ui-icon-closethick" },
                  text: false
              });
          }


### PR DESCRIPTION
I think the "ban" icon to cancel edit not passes/represents the right idea to the action. The "cancel/close" icon is more appropriate (if "close", it's canceled, right?).
