### PR TITLE
Allow arrays for data attributes, fixes #68

### DIFF
--- a/src/editable-form/editable-form-utils.js
+++ b/src/editable-form/editable-form-utils.js
@@ -94,7 +94,7 @@
         getConfigData: function($element) {
             var data = {};
             $.each($element.data(), function(k, v) {
-                if(typeof v !== 'object' || (v && typeof v === 'object' && v.constructor === Object)) {
+                if(typeof v !== 'object' || (v && typeof v === 'object' && (v.constructor === Object || v.constructor === Array))) {
                     data[k] = v;
                 }
             });


### PR DESCRIPTION
jQuery automatically parses json arrays, but the x-editable skips them. This fixes #68.
