### PR TITLE
editable poshytip plain jquery 1.9+ compatibility

### DIFF
--- a/src/containers/editable-poshytip.js
+++ b/src/containers/editable-poshytip.js
@@ -108,7 +108,7 @@
     var tips = [],
     reBgImage = /^url\(["']?([^"'\)]*)["']?\);?$/i,
     rePNG = /\.png$/i,
-    ie6 = $.browser.msie && $.browser.version == 6;
+    ie6 = !!window.createPopup && document.documentElement.currentStyle.minWidth == 'undefined';
     
     $.Poshytip.prototype.refresh = function(async) {
         if (this.disabled)


### PR DESCRIPTION
This adds support for jQuery 1.9+ as shown by the latest Poshytip library.

The main problem is, that jQuery 1.9 drops the `$.browser` support, so detecting the IE6 is no longer possible using `$.browser.msie`.

A possible substitution is already present in the latest Poshytip library, which i adapted here.
