### PR TITLE
Add strict jquery only distribution

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -41,6 +41,12 @@ function getFiles() {
                inputs+'dateui/dateui.js',
                inputs+'dateui/dateuifield.js'
             ],            
+            css: [containers+'editable-poshytip.css']
+        },  
+        plain: {
+            form: [],
+            container: [],
+            inputs: [],            
             css: []
         }      
     };

--- a/src/containers/editable-container.css
+++ b/src/containers/editable-container.css
@@ -1,6 +1,3 @@
-.editable-container {
-    max-width: none !important; /* without this rule poshytip/tooltip does not stretch */
-}  
 
 .editable-container.popover {
 /*   width: 300px;*/  /* debug */

--- a/src/containers/editable-poshytip.css
+++ b/src/containers/editable-poshytip.css
@@ -1,0 +1,3 @@
+.editable-container {
+    max-width: none !important; /* without this rule poshytip/tooltip does not stretch */
+}  


### PR DESCRIPTION
Adding strict jquery only distribution that does not supports only 'inline' edit mode. 

Moving poshytip specific css into its own css file that only gets included in its own distribution.
