### PR TITLE
Adding maxlength attribute to Text and Textarea input types.

### DIFF
--- a/src/inputs/text.js
+++ b/src/inputs/text.js
@@ -28,6 +28,7 @@ $(function(){
         render: function() {
            this.renderClear();
            this.setClass();
+           this.setAttr('maxlength');
            this.setAttr('placeholder');
         },
         
@@ -126,7 +127,16 @@ $(function(){
         @type boolean
         @default true        
         **/
-        clear: true
+        clear: true,
+                
+        /**
+        Maxlength atttribute of input. Specifies the maximum allowable length for the input.   
+        
+        @property maxlength
+        @type integer
+        @default null        
+        **/
+        maxlength: null
     });
 
     $.fn.editabletypes.text = Text;

--- a/src/inputs/textarea.js
+++ b/src/inputs/textarea.js
@@ -28,6 +28,7 @@ $(function(){
     $.extend(Textarea.prototype, {
         render: function () {
             this.setClass();
+            this.setAttr('maxlength');
             this.setAttr('placeholder');
             this.setAttr('rows');                        
             
@@ -101,7 +102,16 @@ $(function(){
         @type integer
         @default 7
         **/        
-        rows: 7        
+        rows: 7,
+                        
+        /**
+        Maxlength atttribute of input. Specifies the maximum allowable length for the input.   
+        
+        @property maxlength
+        @type integer
+        @default null        
+        **/
+        maxlength: null        
     });
 
     $.fn.editabletypes.textarea = Textarea;

--- a/test/unit/text.js
+++ b/test/unit/text.js
@@ -17,6 +17,16 @@ $(function () {
         ok(!p.is(':visible'), 'popover was removed');
       });
       
+     test("option 'maxlength'", function () {
+        var  e = $('<a href="#" id="a" data-maxlength="10"> </a>').appendTo('#qunit-fixture').editable();
+            
+        e.click();
+        var p = tip(e);
+        equal(p.find('input[type=text]').attr('maxlength'), 10, 'maxlength exists');
+        p.find('.editable-cancel').click(); 
+        ok(!p.is(':visible'), 'popover was removed');
+      });
+      
     
      asyncTest("should load correct value and save new entered text (and value)", function () {
         var  v = 'ab<b>"',

--- a/test/unit/textarea.js
+++ b/test/unit/textarea.js
@@ -29,6 +29,15 @@ $(function () {
         ok(!p.is(':visible'), 'popover was removed');         
       })      
       
+     test("maxlength", function () {
+        var e = $('<a href="#" data-type="textarea"></a>').appendTo('#qunit-fixture').editable({maxlength: 10})
+        e.click()
+        var p = tip(e);
+        equal(p.find('textarea').attr('maxlength'), 10, 'maxlength exists');        
+        p.find('.editable-cancel').click(); 
+        ok(!p.is(':visible'), 'popover was removed');         
+      })   
+      
      
      asyncTest("should load correct value and save new entered text (and value)", function () {
         var e = $('<a href="#" data-pk="1" data-url="post.php">'+v1+'</a>').appendTo(fx).editable({


### PR DESCRIPTION
Hi,

I'd like to add support for the maxlength attribute on Text and Textarea input types.

I know that maxlength on Textarea is an HTML5 attribute, but this will allow us to continue using a plugin to add maxlength support on browsers that don't support it (IE)

Thanks!
