### PR TITLE
Support for HTML5 time

### DIFF
--- a/src/inputs/html5types.js
+++ b/src/inputs/html5types.js
@@ -8,6 +8,7 @@ Following types are supported:
 * tel
 * number
 * range
+* time
 
 Learn more about html5 inputs:  
 http://www.w3.org/wiki/HTML5_form_additions  
@@ -192,4 +193,20 @@ Range (inherit from number)
         inputclass: 'input-medium'
     });
     $.fn.editabletypes.range = Range;
+}(window.jQuery));
+
+/*
+Time
+*/
+(function ($) {
+    "use strict";
+
+    var Time = function (options) {
+        this.init('time', options, Time.defaults);
+    };
+    $.fn.editableutils.inherit(Time, $.fn.editabletypes.text);
+    Time.defaults = $.extend({}, $.fn.editabletypes.text.defaults, {
+        tpl: '<input type="time">'
+    });
+    $.fn.editabletypes.time = Time;
 }(window.jQuery));


### PR DESCRIPTION
Added support for HTML5's `time` input type, using code from the other HTML5 types already made.

Tested this on my system and it works well apart from the following error when clicking on the clickable field:

> Uncaught TypeError: Calling setSelectionRange on an input element that cannot have a selection.

As I'm running the minified js I can't pinpoint where exactly this happens.
