### PR TITLE
Enables installation via bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,14 @@
 {
   "name": "x-editable",
   "version": "1.4.6",
-  "main": "dist/README.md",
   "ignore": [
-    "*.*",
+    "CHANGELOG.txt",
+    "Gruntfile.js",
     "LICENSE-MIT",
+    "Package.nuspec",
+    "README.md",
+    "composer.json",
+    "package.json",
     "node_modules",
     "components",
     "src",


### PR DESCRIPTION
The current bower.json leads to an empty x-edito directory. Based on a hint from https://github.com/bower/bower/issues/865#issuecomment-24032373, bower.json has been updated.
