### PR TITLE
Missing "cancel" flag

### DIFF
--- a/src/containers/editable-container.js
+++ b/src/containers/editable-container.js
@@ -50,7 +50,7 @@ Applied as jQuery method.
                 //close all on escape
                 $(document).on('keyup.editable', function (e) {
                     if (e.which === 27) {
-                        $('.editable-open').editableContainer('hide');
+                        $('.editable-open').editableContainer('hide', 'cancel');
                         //todo: return focus on element 
                     }
                 });


### PR DESCRIPTION
When the user hits Escape the control is hidden but the "cancel" parameter was not sent as the documentation states. This commit adds the flag.