### PR TITLE
Separate a part of building params

### DIFF
--- a/src/editable-form/editable-form.js
+++ b/src/editable-form/editable-form.js
@@ -312,12 +312,7 @@ Editableform is linked with one of input types, e.g. 'text', 'select' etc.
             if (send) { //send to server
                 this.showLoading();
 
-                //standard params
-                params = {
-                    name: this.options.name || '',
-                    value: submitValue,
-                    pk: pk 
-                };
+                params = this.buildParams(submitValue, pk);
 
                 //additional params
                 if(typeof this.options.params === 'function') {
@@ -340,6 +335,15 @@ Editableform is linked with one of input types, e.g. 'text', 'select' etc.
                 }
             }
         }, 
+
+        buildParams: function (value, pk) {
+          //standard params
+          return {
+            name: this.options.name || '',
+            value: value,
+            pk: pk
+          };
+        },
 
         validate: function (value) {
             if (value === undefined) {


### PR DESCRIPTION
This change is useful for overriding the structure of standard params.

I use X-editable with Rails.
The structure of params for Rails is different from X-editable's default, so I write a library to override it.
https://github.com/tkawa/bootstrap-editable-rails/blob/master/vendor/assets/javascripts/bootstrap-editable-rails.js.coffee
But this code seems more than necessary because it rewrites params forcibly by hooking URL param.

If this change is applied, my library will just look like this:

``` js
EditableForm.prototype.buildParams = function(value, pk) {
  // Build a structure suitable for Rails
};
```

It is very simple and readable.

Of course I can override params by giving function to option, but the option is for users of library.
I want this change for developers of library like me.
