### PR TITLE
workaroud for extra click event in ie 11.

### DIFF
--- a/src/containers/editable-container.js
+++ b/src/containers/editable-container.js
@@ -75,7 +75,9 @@ Applied as jQuery method.
                     //for some reason FF 20 generates extra event (click) in select2 widget with e.target = document
                     //we need to filter it via construction below. See https://github.com/vitalets/x-editable/issues/199
                     //Possibly related to http://stackoverflow.com/questions/10119793/why-does-firefox-react-differently-from-webkit-and-ie-to-click-event-on-selec
-                    if($target.is(document)) {
+                    if ($target.is(document) ||
+                        // ie 11 has similar issue 
+                        $target.is('body')) {
                        return; 
                     }
                     


### PR DESCRIPTION
ie 11 has similar issue as FF 20, the extra click causes the container close all x-editor form. You can repro the issue by trying "Select2 (dropdown mode)" on http://vitalets.github.io/x-editable/demo-bs3.html by ie 11. Below is the screenshot for this issue.
![ie11screenshot](https://cloud.githubusercontent.com/assets/469742/2748265/2be0be82-c7b5-11e3-9d08-12deffa213c3.png)
