### PR TITLE
Properly setting the value of the typeahead

### DIFF
--- a/src/inputs-ext/typeaheadjs/typeaheadjs.js
+++ b/src/inputs-ext/typeaheadjs/typeaheadjs.js
@@ -44,6 +44,10 @@ $(function(){
                 this.$input.typeahead('setQuery', value);
         },
 
+        clear: function() {
+            this.$input.typeahead('setQuery', '');
+        },
+
         render: function() {
             this.renderClear();
             this.setClass();


### PR DESCRIPTION
The extensions sets the val of the input with .val(value) after the typeahead is initialized. But this is not supported by typeahed , it has internal query var. So when you blur the input the value gets cleared. That's why on the demo page when you open form and do nothing and click save the value gets cleared. This commit fixes #577
