### PR TITLE
fixing console errors for number input fields

### DIFF
--- a/src/editable-form/editable-form-utils.js
+++ b/src/editable-form/editable-form-utils.js
@@ -22,7 +22,7 @@
         * see http://stackoverflow.com/questions/499126/jquery-set-cursor-position-in-text-area
         */        
         setCursorPosition: function(elem, pos) {
-            if (elem.setSelectionRange) {
+            if (elem.setSelectionRange && elem.type != "number") {
                 elem.setSelectionRange(pos, pos);
             } else if (elem.createTextRange) {
                 var range = elem.createTextRange();


### PR DESCRIPTION
Was getting a JS console error when calling setSelectionRange:
"Uncaught InvalidStateError: Failed to execute 'setSelectionRange' on 'HTMLInputElement': The input element's type ('number') does not support selection."