### PR TITLE
204 response from server can't remove unsavedclass

### DIFF
--- a/src/element/editable-element.js
+++ b/src/element/editable-element.js
@@ -382,7 +382,7 @@ Makes editable any HTML element on the page. Applied as jQuery method.
                 sent = sent || typeof this.options.url === 'function';
                 sent = sent || this.options.display === false; 
                 sent = sent || params.response !== undefined; 
-                sent = sent || (this.options.savenochange && this.input.value2str(this.value) !== this.input.value2str(params.newValue)); 
+                sent = sent || (this.input.value2str(this.value) !== this.input.value2str(params.newValue));
                 
                 if(sent) {
                     this.$element.removeClass(this.options.unsavedclass); 


### PR DESCRIPTION
If responding with 204, params.response is undefined so `sent` var is still false.
Fix by ignoring savenochange option when determining whether a request is sent.

This will fix https://github.com/bootstrap-ruby/bootstrap-editable-rails/issues/21.
