### PR TITLE
make typeaheadjs extension compat with current twitter typeahead

### DIFF
--- a/src/inputs-ext/typeaheadjs/typeaheadjs.js
+++ b/src/inputs-ext/typeaheadjs/typeaheadjs.js
@@ -68,10 +68,10 @@ $(function(){
         tpl:'<input type="text">',
         /**
         Configuration of typeahead itself. 
-        [Full list of options](https://github.com/twitter/typeahead.js#dataset).
+        [Full list of options](https://github.com/twitter/typeahead.js/blob/master/doc/jquery_typeahead.md#usage).
         
         @property typeahead 
-        @type object
+        @type object or array
         @default null
         **/
         typeahead: null,


### PR DESCRIPTION
Current twitter typeahead is not instantiated with 1 single object. It separates typeahead options from dataset options like this::

jQuery#typeahead(options, [*datasets])

See https://github.com/twitter/typeahead.js/blob/master/doc/jquery_typeahead.md#usage
