### PR TITLE
Use $(html).attr(attrs) instead of $(html, attrs)

### DIFF
--- a/src/inputs/select.js
+++ b/src/inputs/select.js
@@ -45,7 +45,7 @@ $(function(){
                             if(data[i].disabled) {
                                 attr.disabled = true;
                             }
-                            $el.append($('<option>', attr).text(data[i].text)); 
+                            $el.append($('<option>').attr(attr).text(data[i].text)); 
                         }
                     }
                 }


### PR DESCRIPTION
I have some case where select type doesn't work because jQuery produces `<option>val</option>` instead of `<option value='val'></option>`.

By looking in the jQuery code, the initial form will call the object method if available (`value()` in this case) instead of setting the attribute.

This conflict does not happen with the second formand ensure that the value attribute is always set.
