### PR TITLE
fix live editables with inner html bug

### DIFF
--- a/src/element/editable-element.js
+++ b/src/element/editable-element.js
@@ -146,7 +146,7 @@ Makes editable any HTML element on the page. Applied as jQuery method.
            this.options.autotext = 'never';
            //listen toggle events
            this.$element.on(this.options.toggle + '.editable', selector, $.proxy(function(e){
-               var $target = $(e.target);
+               var $target = $(e.target).closest(selector);
                if(!$target.data('editable')) {
                    //if delegated element initially empty, we need to clear it's text (that was manually set to `empty` by user)
                    //see https://github.com/vitalets/x-editable/issues/137 


### PR DESCRIPTION
This fixes bug, which happens when live-editable element conains inner html (see http://stackoverflow.com/questions/26338514/x-editable-child-click-when-using-selector-option)