### PR TITLE
stop css breaking in a popup BS3

### DIFF
--- a/src/editable-form/editable-form.css
+++ b/src/editable-form/editable-form.css
@@ -8,6 +8,12 @@
     line-height: 20px; /* overwriting bootstrap line-height. See #133 */
 }
 
+.form-horizontal .editable-popup .editableform .form-group{
+    /** fix: stop css from breaking when the form is inside a popup and inside a form with the class .form-horizontal **/
+	margin-left:0;
+	margin-right:0;
+}
+
 /* 
   BS3 width:1005 for inputs breaks editable form in popup 
   See: https://github.com/vitalets/x-editable/issues/393


### PR DESCRIPTION
Fix when the edit `popup` is inside a `form` with class `form-horizontal` and the CSS breaks in bootstrap 3

**Overriding CSS in Bootstrap 3 theme:**

```
.form-horizontal .form-group {
    margin-left: -15px;
    margin-right: -15px;
}
```
