### PR TITLE
Check if select2 input exists before destroy

### DIFF
--- a/src/inputs/select2/select2.js
+++ b/src/inputs/select2/select2.js
@@ -294,9 +294,11 @@ $(function(){
         },
         
         destroy: function() {
-            if(this.$input.data('select2')) {
-                this.$input.select2('destroy');
-            }
+	        if(this.$input) {
+	            if(this.$input.data('select2')) {
+	                this.$input.select2('destroy');
+	            }
+	        }
         }
         
     });


### PR DESCRIPTION
Avoiding TypeError of accessing property ‘data’ on an undefined error.
This error occurs when destroying an editable with input type select2
before the select2 has been created.