### PR TITLE
fix malformed header in fastcgi

### DIFF
--- a/backend-samples/php/post.php
+++ b/backend-samples/php/post.php
@@ -35,7 +35,7 @@
         Response body will be shown as error message in editable form.
         */
 
-        header('HTTP 400 Bad Request', true, 400);
+        header('HTTP/1.0 400 Bad Request', true, 400);
         echo "This field is required!";
     }
 


### PR DESCRIPTION
Hi :
Keep in mind that this is my first php project and first time. Ok ...... Good.

When I used php 5.3 to test my code through fastcgi (apache server on localhost)

[Sun Apr 12 10:17:24.016111 2015] [fastcgi:error] [pid 11178] [client 127.0.0.1:38660] FastCGI: comm with server "/var/www/cgi-bin/php-cgi-5.3.23" aborted: error parsing headers: malformed header 'HTTP 400 Bad Request', referer: http://XXXX.dev/XXXX.php

adding "/1.0"  solve my problem.