### PR TITLE
handle the .destroy() call to properly remove the editor

### DIFF
--- a/src/inputs-ext/wysihtml5/wysihtml5.js
+++ b/src/inputs-ext/wysihtml5/wysihtml5.js
@@ -98,6 +98,9 @@ $(function(){
                 //e.g. '<img>', '<br>', '<p></p>'
                 return !$element.height() || !$element.width();
             } 
+        },
+        destroy:function (){
+        	this.$input.data('wysihtml5').editor.destroy();
         }
     });
 


### PR DESCRIPTION
Used with the old xing/wysihtml5 code the plugin worked fine without this but with Voog/wysihtml it takes to call that or the editor will keep looking for its IFRAME and will throw lots of errors.
And it's good to call that anyway.
