### PR TITLE
default value for combodate.maxYear ( must be current year, not 2015 )

### DIFF
--- a/src/inputs/combodate/lib/combodate.js
+++ b/src/inputs/combodate/lib/combodate.js
@@ -473,7 +473,7 @@
         //initial value, can be `new Date()`    
         value: null,                       
         minYear: 1970,
-        maxYear: 2015,
+        maxYear: (new Date().getFullYear()),
         yearDescending: true,
         minuteStep: 5,
         secondStep: 1,


### PR DESCRIPTION
Set default value  for combodate.maxYear to current year