### PR TITLE
Incorrect deferred implementation

### DIFF
--- a/dist/bootstrap3-editable/js/bootstrap-editable.js
+++ b/dist/bootstrap3-editable/js/bootstrap-editable.js
@@ -2574,16 +2574,16 @@ List - abstract class for inputs that have source option loaded from js array or
         },
         
         value2html: function (value, element, display, response) {
-            var deferred = $.Deferred(),
-                success = function () {
-                    if(typeof display === 'function') {
-                        //custom display method
-                        display.call(element, value, this.sourceData, response); 
-                    } else {
-                        this.value2htmlFinal(value, element);
-                    }
-                    deferred.resolve();
-               };
+            var deferred = $.Deferred();
+	        success = deferred.then(function () {
+	            if(typeof display === 'function') {
+	                //custom display method
+	                display.call(element, value, this.sourceData, response); 
+	            } else {
+	                this.value2htmlFinal(value, element);
+	            }
+	            deferred.resolve();
+	       });
             
             //for null value just call success without loading source
             if(value === null) {

--- a/dist/bootstrap3-editable/js/bootstrap-editable.js
+++ b/dist/bootstrap3-editable/js/bootstrap-editable.js
@@ -2574,7 +2574,7 @@ List - abstract class for inputs that have source option loaded from js array or
         },
         
         value2html: function (value, element, display, response) {
-            var deferred = $.Deferred(),
+            var deferred = $.Deferred();
 	        success = deferred.then(function () {
 	            if(typeof display === 'function') {
 	                //custom display method

--- a/dist/bootstrap3-editable/js/bootstrap-editable.js
+++ b/dist/bootstrap3-editable/js/bootstrap-editable.js
@@ -2574,7 +2574,7 @@ List - abstract class for inputs that have source option loaded from js array or
         },
         
         value2html: function (value, element, display, response) {
-            var deferred = $.Deferred();
+            var deferred = $.Deferred(),
 	        success = deferred.then(function () {
 	            if(typeof display === 'function') {
 	                //custom display method


### PR DESCRIPTION
This function creates a success object and a deferred object but the success object is never established as a handler for the deferred.  In practice this means that the display callback is never executed and values are never rendered.