### PR TITLE
Add global default options to specific input type

### DIFF
--- a/src/editable-form/editable-form-utils.js
+++ b/src/editable-form/editable-form-utils.js
@@ -211,6 +211,22 @@
            if(type === 'wysihtml5' && !$.fn.editabletypes[type]) {
                type = 'textarea';
            }
+           
+           
+           var defaults = $.fn.editable.defaults[options.type];
+
+            if (defaults != undefined) {
+    
+                for (var i=0; i<defaults.filters.length; i++) {
+                    var _options = defaults.filters[i](options);
+                    if (_options != undefined) {
+                        options = _options;
+                    }
+                }
+    
+                $.extend(options, defaults);
+            }
+           
 
            //create input of specified type. Input will be used for converting value, not in form
            if(typeof $.fn.editabletypes[type] === 'function') {

--- a/src/element/editable-element.js
+++ b/src/element/editable-element.js
@@ -855,4 +855,19 @@ Makes editable any HTML element on the page. Applied as jQuery method.
         highlight: '#FFFF80'
     };
     
+    
+    var _input_types = Object.keys($.fn.editabletypes);    
+    for (var i=0; i < _input_types.length; i++) {
+        if ($.fn.editable.defaults[_input_types[i]] == undefined) {
+            $.fn.editable.defaults[_input_types[i]] = {
+                filters: [],
+                addFilter: function(callback) {
+                    this.filters.push(callback);
+                }
+            };
+        }
+    }
+    
+    
+    
 }(window.jQuery));


### PR DESCRIPTION
When I worked on a project which uses x-editable, there was a time I only need to set default options to specific types. I can't a way to do it so I just hooked in a method in x-editable...

https://github.com/WisdomSky/jquery-x-editable-defaults