### PR TITLE
implement the activate() method so the editor will receive focus

### DIFF
--- a/src/inputs/select2/select2.js
+++ b/src/inputs/select2/select2.js
@@ -293,6 +293,10 @@ $(function(){
             return source;
         },
         
+        activate: function() {
+        	this.$input.select2('open');
+        },
+        
         destroy: function() {
             if(this.$input.data('select2')) {
                 this.$input.select2('destroy');


### PR DESCRIPTION
The base editable plugin invokes a method named "activate" which in other implementations sets focus on the editor's main editing element. The select2 editor does not implement that method and it does not receive focus when opened and the user has to click the editor to start using it. This inconsistency leads to a worse UX and this commit adds the missing implementation.

it is the exact issue descirbed in #646 but with a proper solution.

Cheers