### PR TITLE
Fix for scenario with data-value="null" & no text content. Instead of "null", "Empty" is shown on UI.

### DIFF
--- a/src/editable-form/editable-form-utils.js
+++ b/src/editable-form/editable-form-utils.js
@@ -95,7 +95,7 @@
         */
         getConfigData: function($element) {
             var data = {};
-            $.each($element.data(), function(k, v) {
+            $.each($element[0].dataset, function(k, v) {
                 if(typeof v !== 'object' || (v && typeof v === 'object' && (v.constructor === Object || v.constructor === Array))) {
                     data[k] = v;
                 }

--- a/test/unit/common.js
+++ b/test/unit/common.js
@@ -49,7 +49,8 @@
             esc_v = $('<div>').text(v).html(),
             e = $('<a href="#123" data-name="abc" data-value="123">qwe</a>').appendTo('#qunit-fixture').editable(),
             e2 = $('<a href="#" id="a2">'+v+'</a>').appendTo('#qunit-fixture').editable(),
-            e3 = $('<a href="#" id="a3">'+esc_v+'</a>').appendTo('#qunit-fixture').editable();
+            e3 = $('<a href="#" id="a3">'+esc_v+'</a>').appendTo('#qunit-fixture').editable(),
+            e4 = $('<a href="#" id="a4" data-value="null"></a>').appendTo('#qunit-fixture').editable();
        
         equal(e.data('editable').options.name, 'abc', 'name exists');
         equal(e.data('editable').value, '123', 'value exists');
@@ -59,7 +60,9 @@
 //        equal(e2.data('editable').lastSavedValue, visible_v, 'lastSavedValue taken from text correctly');  
         
         equal(e3.data('editable').value, v, 'value taken from elem content correctly (escaped)');     
-//        equal(e3.data('editable').lastSavedValue, v, 'lastSavedValue taken from text correctly (escaped)');             
+//        equal(e3.data('editable').lastSavedValue, v, 'lastSavedValue taken from text correctly (escaped)');
+
+        equal(e4.data('editable').value, "null", 'value "null" taken from elem\'s data-attribute "data-value" correctly');
       }); 
       
       test("container's title and placement from json options", function () {


### PR DESCRIPTION
When the editable HTML element has **blank** textContent, but has an attribute '**data-value**' with the value "**null**", the UI shows the '**Empty**' placeholder string. 

`<a href="#" data-value="null"></a>`

Instead, the string "**null**" should be visible on UI. 

This is occurring because the **jQuery data()** function used to retrieve the data attributes automatically converts the string **"null"** into a **null value** which gets **ignored**. 

The fix involves instead using the HTML Element's '**dataset**' property for retrieving the map of data attribute keys & values - all as strings.

JS Fiddles for checking:
1) Bug: https://jsfiddle.net/transopac/rej5w2w3/
2) Fix for Bug: https://jsfiddle.net/transopac/xhmsv7yb/

Similar to above fiddles showing bug/fix - BUT using the provided JS Fiddle template (didn't see this link earlier): 
Bug: http://jsfiddle.net/transopac/xBB5x/14683/
Fix: http://jsfiddle.net/transopac/xBB5x/14684/